### PR TITLE
Fix related entity query

### DIFF
--- a/src/mcp_server_pubtator3/pubtator_client.py
+++ b/src/mcp_server_pubtator3/pubtator_client.py
@@ -169,17 +169,24 @@ class PubtatorClient:
             'positive_correlate', 'negative_correlate', 'prevent', 'inhibit', 'stimulate', 'drug_interact'
         }
 
-        params = {'e1': entity_id}
+        url = f"{self.base_url}relations?e1={entity_id}"
         if relation_type:
             if relation_type not in VALID_RELATION_TYPES:
-                raise ValueError(f"Invalid relation_type: {relation_type}. Must be one of {VALID_RELATION_TYPES}")
-            params['type'] = relation_type
+                raise ValueError(
+                    f"Invalid relation_type: {relation_type}. Must be one of {VALID_RELATION_TYPES}"
+                )
+            url += f"&type={relation_type}"
         if entity_type:
             if entity_type not in VALID_ENTITY_TYPES:
-                raise ValueError(f"Invalid entity_type: {entity_type}. Must be one of {VALID_ENTITY_TYPES}")
-            params['e2'] = entity_type
+                raise ValueError(
+                    f"Invalid entity_type: {entity_type}. Must be one of {VALID_ENTITY_TYPES}"
+                )
+            url += f"&e2={entity_type}"
 
-        url = f"{self.base_url}relations"
         async with aiohttp.ClientSession() as session:
-            resp = await self._rate_limited_request(url, session, json=True)
+            resp = await self._rate_limited_request(
+                url,
+                session,
+                json=True,
+            )
             return json.dumps(resp)


### PR DESCRIPTION
## Summary
- ensure parameters are in the query string when querying related entities

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840ed6f76f08321ad7a57ee6f200e6d